### PR TITLE
Fix: friend list with more than 100 friends

### DIFF
--- a/SteamApi/User.php
+++ b/SteamApi/User.php
@@ -83,12 +83,18 @@ class User extends Client implements IUser {
 
 		// Clean up the games
 		$steamIds = array();
+		$friends = array();
 
 		foreach ($client->friends as $friend) {
 			$steamIds[] = $friend->steamid;
+			if (count($steamIds) == 100) {
+				$friends = array_merge($friends, $this->GetPlayerSummaries(implode(',', $steamIds)));
+				$steamIds = array();
+			}
 		}
 
-		$friends = $this->GetPlayerSummaries(implode(',', $steamIds));
+		if (count($steamIds) > 0)
+			$friends = array_merge($friends, $this->GetPlayerSummaries(implode(',', $steamIds)));
 
 		return $friends;
 	}


### PR DESCRIPTION
When friend list have more than 100 friends, only first 100 friends was
previously returned.
